### PR TITLE
Add organization_people endpoint

### DIFF
--- a/lib/mobilize_america_client/client.rb
+++ b/lib/mobilize_america_client/client.rb
@@ -4,6 +4,7 @@ require 'mobilize_america_client/client/attendances'
 require 'mobilize_america_client/client/enums'
 require 'mobilize_america_client/client/events'
 require 'mobilize_america_client/client/organizations'
+require 'mobilize_america_client/client/people'
 require 'mobilize_america_client/request'
 require 'mobilize_america_client/errors'
 
@@ -28,5 +29,6 @@ module MobilizeAmericaClient
     include MobilizeAmericaClient::Client::Enums
     include MobilizeAmericaClient::Client::Events
     include MobilizeAmericaClient::Client::Organizations
+    include MobilizeAmericaClient::Client::People
   end
 end

--- a/lib/mobilize_america_client/client/people.rb
+++ b/lib/mobilize_america_client/client/people.rb
@@ -1,0 +1,27 @@
+module MobilizeAmericaClient
+  class Client
+    module People
+      def organization_people(organization_id:, updated_since: nil, cursor: nil, page: nil, per_page: nil)
+        params = {}
+
+        unless updated_since.nil?
+          params[:updated_since] = updated_since.to_i
+        end
+
+        unless cursor.nil?
+          params[:cursor] = cursor
+        end
+
+        unless page.nil?
+          params[:page] = page
+        end
+
+        unless per_page.nil?
+          params[:per_page] = per_page
+        end
+
+        get(path: "/organizations/#{esc(organization_id)}/people", params: params)
+      end
+    end
+  end
+end

--- a/lib/mobilize_america_client/version.rb
+++ b/lib/mobilize_america_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MobilizeAmericaClient
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/spec/client/people_spec.rb
+++ b/spec/client/people_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe MobilizeAmericaClient::Client::People do
+  let(:api_key) { 'abcde-123456' }
+  let(:expected_headers) { {'Content-Type' => 'application/json', 'Authorization' => "Bearer #{api_key}"} }
+  let(:base_url) { "https://#{MobilizeAmericaClient::Client::API_DOMAIN}#{MobilizeAmericaClient::Client::API_BASE_PATH}" }
+
+  subject { MobilizeAmericaClient::Client.new(api_key: api_key) }
+
+  describe '#organization_people' do
+    let(:org_id) { 123 }
+    let(:people_url) { "#{base_url}/organizations/#{org_id}/people" }
+    let(:response) { {'data' => [{'id' => 1, 'given_name' => 'Alice'}, {'id' => 2, 'given_name' => 'Bob'}]} }
+    let(:response_headers) { {'Content-Type' => 'application/json'} }
+
+    it 'should raise if response status is 401' do
+      stub_request(:get, people_url).with(headers: expected_headers).to_return(status: 401, body: {error: 'unauthorized'}.to_json)
+
+      expect { subject.organization_people(organization_id: org_id) }.to raise_error MobilizeAmericaClient::UnauthorizedError
+    end
+
+    it 'should raise if response status is 404' do
+      stub_request(:get, people_url).with(headers: expected_headers).to_return(status: 404, body: {error: 'not found'}.to_json)
+
+      expect { subject.organization_people(organization_id: org_id) }.to raise_error MobilizeAmericaClient::NotFoundError
+    end
+
+    it 'should call the endpoint and return JSON' do
+      stub_request(:get, people_url).with(headers: expected_headers).to_return(body: response.to_json, headers: response_headers)
+      expect(subject.organization_people(organization_id: org_id)).to eq(response)
+    end
+
+    it 'should escape the organization ID' do
+      expected_url = "#{base_url}/organizations/foo%2Fbar/people"
+      stub_request(:get, expected_url).with(headers: expected_headers).to_return(body: response.to_json, headers: response_headers)
+      expect(subject.organization_people(organization_id: 'foo/bar')).to eq(response)
+    end
+
+    it 'should support an updated_since parameter' do
+      updated_since = Time.new
+      stub_request(:get, people_url)
+        .with(headers: expected_headers, query: {updated_since: updated_since.to_i})
+        .to_return(body: response.to_json, headers: response_headers)
+      expect(subject.organization_people(organization_id: org_id, updated_since: updated_since)).to eq(response)
+    end
+
+    it 'should support a cursor parameter' do
+      stub_request(:get, people_url)
+        .with(headers: expected_headers, query: {cursor: 'abc123'})
+        .to_return(body: response.to_json, headers: response_headers)
+      expect(subject.organization_people(organization_id: org_id, cursor: 'abc123')).to eq(response)
+    end
+
+    it 'should support pagination parameters' do
+      stub_request(:get, people_url)
+        .with(headers: expected_headers, query: {page: 2, per_page: 100})
+        .to_return(body: response.to_json, headers: response_headers)
+      expect(subject.organization_people(organization_id: org_id, page: 2, per_page: 100)).to eq(response)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `organization_people(organization_id:, updated_since:, cursor:, page:, per_page:)` mirroring the existing `organization_attendances` helper
- Bumps version to 0.7.0

## Motivation
Nashville is adding a low-frequency mirror of Mobilize's `/organizations/{id}/people` so event hosts (and other Mobilize users who never RSVP) land in our People list. Today they're invisible because they don't show up in the attendances API.

## Test plan
- [x] `bundle exec rspec spec/client/people_spec.rb` (7 examples, 0 failures)
- [ ] Nashville bundles the new gem ref and runs its `MobilizeAmericaSync::FetchPeople` job specs against a real Mobilize sandbox org

🤖 Generated with [Claude Code](https://claude.com/claude-code)